### PR TITLE
Fix resourceless tokens never playing their music.

### DIFF
--- a/module/token.js
+++ b/module/token.js
@@ -108,7 +108,7 @@ export function getTokenMusic(token) {
     const musicList = token.getFlag(SYSTEM_ID, 'musicList');
     if (!musicList)
         return;
-    const attrThreshold = (100 * attribute.value) / attribute.max;
+    const attrThreshold = attribute.max === 0 ? 100 : (100 * attribute.value) / attribute.max;
     for (let i = musicList.length; i > 0; i--) {
         const [music, threshold] = musicList[i - 1];
         if (attrThreshold <= threshold) {

--- a/module/token.ts
+++ b/module/token.ts
@@ -148,7 +148,8 @@ export function getTokenMusic(token: TokenDocument) {
 	const musicList = token.getFlag(SYSTEM_ID, 'musicList') as [string, number][] | undefined;
 	if (!musicList) return;
 
-	const attrThreshold = (100 * attribute.value) / attribute.max;
+	// Default to 100 when max is 0 to support haunts and other resourceless hazards having music
+	const attrThreshold = attribute.max === 0 ? 100 : (100 * attribute.value) / attribute.max;
 	for (let i = musicList.length; i > 0; i--) {
 		const [music, threshold] = musicList[i - 1];
 		if (attrThreshold <= threshold) {


### PR DESCRIPTION
**TLDR** This PR makes resourceless tokens (like many haunts) able to play their music.

## Motivation
I'm running PF2E campaigns, which often involve haunts. Haunts are proper tokens with initiative, actions, and sometimes even DCs. Unfortunately, they tend not to have HP or any other relevant resources. }

![image](https://user-images.githubusercontent.com/4889856/227680388-bb8e593a-d56b-4fc3-949c-7b83458e374e.png)

As such I've had to make this change locally in order to get haunts to play their music.

## Cause
When the module tries to figure out which playlist to play for a haunt in [Token.ts](https://github.com/elizeuangelo/fvtt-module-combat-music-master/blob/cc6140863d9ecae1a476136a940515c947f36469/module/token.ts#L151) we end up dividing by `attribute.max` and creating a NaN via division by zero. Since `NaN` is super weird, we can't ever get a true back from checking if it is greater or less than the current value. This means there is *no setting* that can cause the music to play, since NaN is neither less nor greater than any number.
![image](https://user-images.githubusercontent.com/4889856/227680499-6b79cc54-a94d-4b9f-abfb-9037a9aabe88.png)


## Reproduction
- Create or place a haunt. An example (from abomination vaults) looks like this
![image](https://user-images.githubusercontent.com/4889856/227680290-e9ca5609-edce-4110-a15a-e6f7b37eb85a.png)
- Give it music using the tab this module adds
![image](https://user-images.githubusercontent.com/4889856/227680313-727c7314-b4f0-4a56-815f-62c39a6a8ce3.png)
- Create a combat and add the token
![image](https://user-images.githubusercontent.com/4889856/227680418-7ab55fc6-28a5-41e9-9daa-1d274b69d5d9.png)
- Begin combat
You will hear your default playlists play on the current main branch, and the token's music on mine.

